### PR TITLE
fix search_hostname function

### DIFF
--- a/phpipamsdk/controllers/addresses_api.py
+++ b/phpipamsdk/controllers/addresses_api.py
@@ -71,7 +71,7 @@ class AddressesApi(object):
 
     def search_hostname(self, hostname=''):
         """ search for hostname """
-        uri = 'addresses/search/' + str(hostname) + '/'
+        uri = 'addresses/search_hostname/' + str(hostname) + '/'
         result = self.phpipam.api_send_request(path=uri, method='get')
         return result
 


### PR DESCRIPTION
I think that search_hostname function should be fixed to match [phpipam's API search_hostname](https://phpipam.net/api/api_reference/)